### PR TITLE
Change PB link to POD-specific link

### DIFF
--- a/dailyPinkbikeWallpaper.py
+++ b/dailyPinkbikeWallpaper.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 
-r = requests.get("https://www.pinkbike.com/")
+r = requests.get("https://www.pinkbike.com/photo/podlist/")
 data = r.text
 soup = BeautifulSoup(data, "lxml")
 

--- a/dailyPinkbikeWallpaperWindows10.py
+++ b/dailyPinkbikeWallpaperWindows10.py
@@ -7,7 +7,7 @@ import ctypes
 import sys
 
 
-r = requests.get("https://www.pinkbike.com/")
+r = requests.get("https://www.pinkbike.com/photo/podlist/")
 data = r.text
 soup = BeautifulSoup(data, "lxml")
 


### PR DESCRIPTION
as of now (10.2.2019) the regular PB link doesn't work to retrieve the photolinks anymore.

Fix: changing it to the specific POD link (https://www.pinkbike.com/photo/podlist/) 